### PR TITLE
chore: configure grouped releases and sync versions to 1.9.0

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/flarelette-jwt-ts": "1.9.0",
-  "packages/flarelette-jwt-py": "1.8.4"
+  "packages/flarelette-jwt-py": "1.9.0"
 }

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "include-component-in-tag": true,
+  "group-pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     "packages/flarelette-jwt-ts": {
       "release-type": "node",
@@ -49,6 +50,11 @@
         { "type": "test", "section": "Tests", "hidden": false },
         { "type": "chore", "section": "Miscellaneous", "hidden": false }
       ]
+    }
+  },
+  "groups": {
+    "flarelette-jwt-kit": {
+      "packages": ["packages/flarelette-jwt-ts", "packages/flarelette-jwt-py"]
     }
   },
   "bootstrap-sha": "HEAD"

--- a/packages/flarelette-jwt-py/flarelette_jwt/__init__.py
+++ b/packages/flarelette-jwt-py/flarelette_jwt/__init__.py
@@ -23,7 +23,7 @@ from .sign import sign
 from .util import ParsedJwt, is_expiring_soon, map_scopes_to_permissions, parse
 from .verify import verify
 
-__version__ = "1.8.4"
+__version__ = "1.9.0"
 
 __all__ = [
     # Types

--- a/packages/flarelette-jwt-py/pyproject.toml
+++ b/packages/flarelette-jwt-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flarelette-jwt"
-version = "1.8.4"
+version = "1.9.0"
 description = "Environment-driven JWT authentication for Cloudflare Workers Python with secret-name indirection"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
- Add release-please groups to keep TypeScript and Python packages synchronized
- Bump Python package from 1.8.4 to 1.9.0 to match TypeScript
- Future releases will maintain version parity across both packages

Written-by: Chris Lyons