### PR TITLE
fix: use correct types for workerenv

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -17,7 +17,7 @@ The TypeScript package depends on the following NPM packages:
 @flarelette/jwt-kit-env@1.8.1
 │ C:\Users\chris\git\flarelette-jwt-kit
 │
-└─┬ @chrislyons-dev/flarelette-jwt@1.8.3 -> .\packages\flarelette-jwt-ts
+└─┬ @chrislyons-dev/flarelette-jwt@1.9.0 -> .\packages\flarelette-jwt-ts
   │ Environment-driven JWT authentication for Cloudflare Workers with secret-name indirection
   └── jose@5.10.0
       JWA, JWS, JWE, JWT, JWK, JWKS for Node.js, Browser, Cloudflare Workers, Deno, Bun, and other Web-interoperable runtimes

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,7 +1,7 @@
 # 🏗️ flarelette-jwt-kit
 
 **Architecture Documentation**
-Generated 2025-11-02 06:03:12
+Generated 2025-11-02 07:09:15
 
 ## Overview
 

--- a/packages/flarelette-jwt-ts/src/types.ts
+++ b/packages/flarelette-jwt-ts/src/types.ts
@@ -218,8 +218,8 @@ export interface Fetcher {
  */
 export interface WorkerEnv extends Record<string, unknown> {
   // Standard environment variables (strings)
-  JWT_ISS?: JwtValue
-  JWT_AUD?: JwtValue
+  JWT_ISS?: string
+  JWT_AUD?: string
   JWT_TTL_SECONDS?: string
   JWT_LEEWAY?: string
   JWT_KID?: string


### PR DESCRIPTION
Use string types instead of JwtValue in WorkerEnv.

Written-by: Chris Lyons